### PR TITLE
isolate agg/part dispatch in the main; “smart” infect2!

### DIFF
--- a/data/by-tract/ALLap_417-init.csv
+++ b/data/by-tract/ALLap_417-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dec1b7751fb0b19265aeb875bb89f8c0046be669c7c2ca5b0076e1cf276a38f
+size 28018

--- a/data/by-tract/ALLap_417-init.csv
+++ b/data/by-tract/ALLap_417-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3dec1b7751fb0b19265aeb875bb89f8c0046be669c7c2ca5b0076e1cf276a38f
+oid sha256:12ed1af2c0b1553739b4d2cab4207ccbe98942bdd7321f2aa834b29e4d286ba9
 size 28018

--- a/data/by-tract/ALLap_417-trav.dat
+++ b/data/by-tract/ALLap_417-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b87bfccd1b86c199e9a66a8c1da72c2b0f1bc7ef92cd27db15268ec1a28879
+size 891686

--- a/data/by-tract/ALLcty_3109-init.csv
+++ b/data/by-tract/ALLcty_3109-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d80c8784966f6131c797c4f0ec26df6bffc3a5fd71fd590e56fecb9aba6a64c8
+size 207313

--- a/data/by-tract/ALLcty_3109-init.csv
+++ b/data/by-tract/ALLcty_3109-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d80c8784966f6131c797c4f0ec26df6bffc3a5fd71fd590e56fecb9aba6a64c8
+oid sha256:04b3d10a3b8e5aa89ce425fe1539e617d771023b267fa45f74a1d9ae1f3a7eb8
 size 207313

--- a/data/by-tract/ALLcty_3109-trav.dat
+++ b/data/by-tract/ALLcty_3109-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65afe880c13b0e07272dbf4d473901457c77d3f465aa8eabdc914f0a43f92361
+size 70181993

--- a/data/by-tract/ALLste_49-init.csv
+++ b/data/by-tract/ALLste_49-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:560e1fef07d11832d10831dd0dacfd3877e5b5e0f3e5f4cd9c3cf877bc129bfa
+oid sha256:7ea2f589688bddfda6a53e337e086f8fade7c815a5fd353d7b83b43e1a40ee3f
 size 3431

--- a/data/by-tract/ALLste_49-init.csv
+++ b/data/by-tract/ALLste_49-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:560e1fef07d11832d10831dd0dacfd3877e5b5e0f3e5f4cd9c3cf877bc129bfa
+size 3431

--- a/data/by-tract/ALLste_49-trav.dat
+++ b/data/by-tract/ALLste_49-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f359824974ddfa512c6965586773aa335ce3ab2beba9ac4356c80019bbfadc8
+size 42818

--- a/data/by-tract/CAap_32-init.csv
+++ b/data/by-tract/CAap_32-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b85569d8f4385a5a62803f22d6e282e650bc84f32f9a53d3b27c3bbe2be04c5c
+size 2198

--- a/data/by-tract/CAap_32-trav.dat
+++ b/data/by-tract/CAap_32-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac35dfb98bf1f76169d958d0ee450d24563b6025ec65d3807bf4d4fbc8406d18
+size 8778

--- a/data/by-tract/CActy_58-init.csv
+++ b/data/by-tract/CActy_58-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb49ac4cfca99defe36dea7641ee0ed36895cc82750e288e43ae5d06f394522e
+size 4154

--- a/data/by-tract/CActy_58-trav.dat
+++ b/data/by-tract/CActy_58-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e04b3dd33aae95553eebd512f23a2f5bf097b2fabde84853e9a04ef2dbc97742
+size 39777

--- a/data/by-tract/CAste_1-init.csv
+++ b/data/by-tract/CAste_1-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a60d37bd571a2eab492fe0e5dd4447c8011d5361e27176b46ce07c7d311afd
+size 112

--- a/data/by-tract/CAste_1-init.csv
+++ b/data/by-tract/CAste_1-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36a60d37bd571a2eab492fe0e5dd4447c8011d5361e27176b46ce07c7d311afd
-size 112

--- a/data/by-tract/CAste_1-trav.dat
+++ b/data/by-tract/CAste_1-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51ff0d2f0d3a5d61edec31785532ea0d570f8c348d58b15b94ff9c2ca6e926a4
+size 4

--- a/data/by-tract/CAste_1-trav.dat
+++ b/data/by-tract/CAste_1-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51ff0d2f0d3a5d61edec31785532ea0d570f8c348d58b15b94ff9c2ca6e926a4
-size 4

--- a/data/by-tract/CAtra_7038-init.csv
+++ b/data/by-tract/CAtra_7038-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ab5fa8e0bfb1a4ec2770bd3669a71ad4e5f2bf69a0bec9388554786bc27a8dc
+size 476999

--- a/data/by-tract/CAtra_7038-trav.dat
+++ b/data/by-tract/CAtra_7038-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a079046398f851c46a3e52aa231608f4d576a4d5b285a28f7962bdac1651b2a
+size 621140047

--- a/data/by-tract/GREATLAKESap_80-init.csv
+++ b/data/by-tract/GREATLAKESap_80-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf70cad9f3a3cfaa76eafd2753f021cd77f3bc14076cbab84ebe8c1fd8eac196
-size 5255

--- a/data/by-tract/GREATLAKESap_80-trav.dat
+++ b/data/by-tract/GREATLAKESap_80-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:780c7971d99814d7c0ea266e9683706789c5717dcb253c05dc1f835eb91cc00e
-size 35859

--- a/data/by-tract/MSap_22-init.csv
+++ b/data/by-tract/MSap_22-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db7af8685b4c4c84aec0ab2c6d0685ca56ff2738b3487a32471bdae395b77c24
-size 1430

--- a/data/by-tract/MSap_22-trav.dat
+++ b/data/by-tract/MSap_22-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bf584b78ff54a053b5dd10c2496294818bdeb7058d5ebafb094f965f15c600f
-size 2901

--- a/data/by-tract/NW1ap_37-init.csv
+++ b/data/by-tract/NW1ap_37-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c10ce8a57c566423c2cbe89c817a53dbdef82f62d875e4a1453e92cef8e80d59
+size 2426

--- a/data/by-tract/NW1ap_37-trav.dat
+++ b/data/by-tract/NW1ap_37-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb95caa3c84a76062b3d77d245312045c287383c9888a5aa840382dec72d5445
+size 7930

--- a/data/by-tract/NW1cty_136-init.csv
+++ b/data/by-tract/NW1cty_136-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed5da94976ee1dd71a949fb6279015a91ba133abba3b220460b168f990b5695
+size 9132

--- a/data/by-tract/NW1cty_136-trav.dat
+++ b/data/by-tract/NW1cty_136-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:104b6849516f6fc49a59e395df64e4ce694e24ed64cc75730239c0b9f52cd779
+size 153006

--- a/data/by-tract/NW1ste_4-init.csv
+++ b/data/by-tract/NW1ste_4-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8fbb9021c8ec60b0a0b42d8c209fc5e90819716ec3f956c734dbaa408c8c5c3
+size 321

--- a/data/by-tract/NW1ste_4-trav.dat
+++ b/data/by-tract/NW1ste_4-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:020c3192f4170d7fbf7ad7e7f2331c0cfd47bdd80a3839c95dad52a3c96cc29c
+size 239

--- a/data/by-tract/NW1tra_2834-init.csv
+++ b/data/by-tract/NW1tra_2834-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5deeca371e64900b15b8532e26dad44a82cd3a084e3851f26a5df673315c455e
+size 192139

--- a/data/by-tract/NW1tra_2834-trav.dat
+++ b/data/by-tract/NW1tra_2834-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6201a3b1f595542f8bd2cdcd7c8ae96539de312ca448e4b5754226b2db02ce93
+size 93786822

--- a/data/by-tract/NW2ap_74-init.csv
+++ b/data/by-tract/NW2ap_74-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef50e3d859dbb666d88640fc3463614ca8e6e8c264bc3db8fc4618802ba0882
+size 4850

--- a/data/by-tract/NW2ap_74-trav.dat
+++ b/data/by-tract/NW2ap_74-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e190682c1c974ec4bd8eb755221a1a9f11b81fccf94d3554cf9081d31a1183bc
+size 29132

--- a/data/by-tract/NW2cty_259-init.csv
+++ b/data/by-tract/NW2cty_259-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e3d2aa1acb866ed7fd93b1ed5efc33be97001457d9f18d6dea1f00df9e4bb12
+size 17122

--- a/data/by-tract/NW2cty_259-trav.dat
+++ b/data/by-tract/NW2cty_259-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c98e45e503cd87840da035f8eb21723ad7ec670f7dab95f407c6dfbaa419df2
+size 444428

--- a/data/by-tract/NW2ste_8-init.csv
+++ b/data/by-tract/NW2ste_8-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49a15a482890b900e0412a848d48720c7a68f2d3c4c6179185ccef6fe835dcc9
+size 597

--- a/data/by-tract/NW2ste_8-trav.dat
+++ b/data/by-tract/NW2ste_8-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c1ed87057f403669b958fddce139a65d130cac4ba02174fa2d089711612a360
+size 1070

--- a/data/by-tract/NW2tra_4830-init.csv
+++ b/data/by-tract/NW2tra_4830-init.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:931d4b6d27275bdb2942ab8cb09a3305cabaaccc390f39523d7c2092b2912414
+size 327242

--- a/data/by-tract/NW2tra_4830-trav.dat
+++ b/data/by-tract/NW2tra_4830-trav.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9a5a68aa3b2f62eabf1e39d124676178ebfe8ecdb21733742a0ddcef05e0f4
+size 256150934

--- a/data/by-tract/OHtra_2930-init.csv
+++ b/data/by-tract/OHtra_2930-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a821729dfc8510046c1aa1d6d90da4e07041a3bed69c3885b28424031ec7c5ce
-size 195437

--- a/data/by-tract/OHtra_2930-trav.dat
+++ b/data/by-tract/OHtra_2930-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50ddc14abfb3b6928fe85fc644e7f8f204ef001c9f216b33a21dfe5176b10020
-size 54657335

--- a/data/by-tract/SOUTHste_5-init.csv
+++ b/data/by-tract/SOUTHste_5-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:baedf1a07da0a369adc9af8efe4c9fae3a5e13e5f538a32e6d6416750b7acc3c
-size 392

--- a/data/by-tract/SOUTHste_5-trav.dat
+++ b/data/by-tract/SOUTHste_5-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1622d0724024ec9efa5808544f4406a2d5c57876f87a40511b3f464244eff212
-size 386

--- a/data/by-tract/TRISTATEcty_91-init.csv
+++ b/data/by-tract/TRISTATEcty_91-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a16589b66f512d52d400ec195d70364580d2b58fc3952b84d85607994b5c3f41
-size 6567

--- a/data/by-tract/TRISTATEcty_91-trav.dat
+++ b/data/by-tract/TRISTATEcty_91-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:757f4d423609632618474bcfba756e567ad6c59fc7a9f9442cf4efe6554464ac
-size 102724

--- a/data/by-tract/WCTap_52-init.csv
+++ b/data/by-tract/WCTap_52-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e453bbebe935840dd58304ac70867e860199049ab9a77419ba2e24a778d5b81
+oid sha256:4d75ccd4f9ee80c23e857fed67e4b9a4679a5be4fa094ead390d9ffd8e8360f7
 size 3517

--- a/data/by-tract/WCTcty_133-init.csv
+++ b/data/by-tract/WCTcty_133-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07a11e54b8680689b8741df09a35e65b16b831d499452c698b167267113080ec
+oid sha256:8ea698ba6b673fd7bdcec3de2d89dcce26588097bd877a717b97f2ec4ad4013f
 size 9320

--- a/data/by-tract/WCTste_3-init.csv
+++ b/data/by-tract/WCTste_3-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5de0a94c919581db514a56bf16bd710550e2409a48bf88ecba3acdfa7765ee1
+oid sha256:5271e9dba8ea0fa935ea283b74cc1471306467ca2611b155bf7a443c682bcbf4
 size 253

--- a/data/by-tract/WCTtra_9110-init.csv
+++ b/data/by-tract/WCTtra_9110-init.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:795f57ae02585dfbe14d4be00c3083af156f87cf540b050757f3a58f30897a9e
+oid sha256:b738cba9f68c975d0a38b43865c1534ed848643219dcf95ada2b32a3801587ee
 size 617486

--- a/data/by-tract/a~NW~cty_75-init.csv
+++ b/data/by-tract/a~NW~cty_75-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e93547e554054a1678f4863fd62bac1577dd6eea6b2efce0d265b16d6e0f438
-size 5208

--- a/data/by-tract/a~NW~cty_75-trav.dat
+++ b/data/by-tract/a~NW~cty_75-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c66975fd52076cdd96eae749cd54f84bfda1338a80e2168c3c5a67719ddc5fd
-size 60227

--- a/data/by-tract/a~NW~ste_2-init.csv
+++ b/data/by-tract/a~NW~ste_2-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:057440f12bd156f1ebc8464cc4cd8f8c45d310e86d4730d5f4e0dd65faa202b1
-size 183

--- a/data/by-tract/a~NW~ste_2-trav.dat
+++ b/data/by-tract/a~NW~ste_2-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f6d19323969fea176b022a9364459a1484a426c9a5bfddfa5f9a9fb73658699
-size 45

--- a/data/by-tract/a~NW~tra_2072-init.csv
+++ b/data/by-tract/a~NW~tra_2072-init.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fc504e8505fca5fc37198d2c0300d83af68923f5af97cb041fb90efece8a03b
-size 140529

--- a/data/by-tract/a~NW~tra_2072-trav.dat
+++ b/data/by-tract/a~NW~tra_2072-trav.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6eba3365660e646ecc893d802210f1845eac9ac953037fbf04343afb77c82a9
-size 46538345

--- a/m-core/sweep.m
+++ b/m-core/sweep.m
@@ -101,10 +101,10 @@ killPsi = false; %(if true, set the terminal cost to 0)
 laxmax=1000; laxmin = -laxmax;
 boundlax = false;
 %boundlax = true; %enforce lax is within bounds
-%% Problem Instance (initial values, populations, and travel matrix)
+%% Set Problem Instance Name
 %inst="NWtra_2072"; %by-tract OR + WS, with flights & commute
 %inst="NWcty_75"; %by-county OR + WS, with flights & commute
-inst="NWap_23"; %by-airport OR + WS, with filghts & commute
+%inst="NWap_23"; %by-airport OR + WS, with filghts & commute
 %inst="NWste_2"; %by-state OR + WS, with flights & commute
 
 %inst="WCTtra_9110"; %WCT is CA + OR + WS
@@ -112,6 +112,23 @@ inst="NWap_23"; %by-airport OR + WS, with filghts & commute
 %inst="WCTap_52";
 %inst="WCTste_3";
 
+%inst="ALLcty_3109";
+%inst="ALLap_417";
+%inst="ALLste_49";
+
+%inst = "NW1tra_2834";
+
+%inst = "NW2ste_8";
+%inst = "NW2ap_74";
+%inst = "NW2cty_259";
+%inst = "NW2tra_4830";
+
+%inst = "CAste_1"; %implementation doesn't support 1-node instances :(
+%inst = "CAap_32";
+%inst = "CActy_58";
+%inst = "CAtra_7038";
+
+%% Read Problem Instance (initial values, populations, and travel matrix)
 % $IV_Path is a .CSV {id,AP_code,N_i,S_i,I_i,R_i,Name,LAT,LNG},
 tIVs = readtable(pathIV(inst));
 

--- a/tools/Oboe/aggregation.jl
+++ b/tools/Oboe/aggregation.jl
@@ -5,7 +5,8 @@ Authors: Yaroslav Salii, 2020+
 Submodule responsible for grouping and aggregating tracts to various levels.
 
 aggregation.jl
-2021-08-13 v.0.1: First modular version
+2021-08-13 v.0.1 First modular version
+2021-09-09 v.0.2 add dummy partByTra to maintain dispatch interface
 """
 module Aggregation
 using DataFrames
@@ -14,6 +15,7 @@ using Statistics: mean
 export aggByCty,
        aggBySte,
        aggByAP,
+       partByTra,
        partByCty,
        partByAP,
        partBySte
@@ -89,6 +91,14 @@ end
 """Map IATA codes in `pns` to lists of node indices in `ns`."""
 function partByAP(ns::DataFrame,pns::DataFrame)
     Dict(x => filter(ri -> ns.IATA_Code[ri]==x, 1:nrow(ns)) for x ∈ pns.IATA_Code |> unique)
+end
+
+"""
+Dummy partition: map each tract name to a 1-vector with its row number.
+Arguments `ns` and `pns` are identical, wit `pns` kept to maintain the partByXX interface
+"""
+function partByTra(ns::DataFrame,pns::DataFrame)
+    Dict( ns.Name[ix] => [ix] for ix ∈ 1:nrow(ns))
 end
 
 """

--- a/tools/Oboe/travel.jl
+++ b/tools/Oboe/travel.jl
@@ -6,10 +6,12 @@ Submodule responsible for producing the commute and air travel matrices.
 
 travel.jl
 2021-08-13 v.0.1: First modular version
+2021-09-11 v.0.1.1 restore `talkDnsy` auxiliary function
 """
 module Travel
 using DataFrames
 using FromFile
+using Statistics,LinearAlgebra #for talkDnsy()
 
 @from "airports.jl" using Airports: FlightMx
 @from "aggregation.jl" using Aggregation: revexplPart
@@ -201,4 +203,24 @@ function psg(fromshr, toshr, totalflow)
     fromshr * toshr * totalflow
 end
 
+"""
+Display (`println`) sparsity-related statistics for commute matrices.
+Computes the input's `density`, the fraction of nonzero elements assuming
+the diagonal may only have zeros, and also the minimum, median, and maximum
+**nonzero** element of the matrix.
+"""
+function talkDnsy(M)
+    dim = size(M,1)
+    if ! (filter(x -> x > 0.0, diag(M)) |> isempty)
+        println(stderr,"Warning: nonzero diagonal elements found.")
+    end 
+    #nonzero entries
+    nzs = filter(x -> x > 0.0, M); a= nzs |> length;
+    dnsy = a/ dim^2; b = dim*(dim-1) #b is max no. nonzero elements (all 'cept diag)
+    println("We've got ",a," ≠0 connections")
+    println("With at most ",b, " ≠0 entries, we get the density ",dnsy)
+    print("min ", nzs |> minimum, "   median ", nzs |> median, "   max ", nzs |> maximum)
+    return(nnonzero = a, maxnonzero= b, density = dnsy, dim = size(M,1))
 end
+
+end #end module Oboe.Travel

--- a/tools/oboe-main.jl
+++ b/tools/oboe-main.jl
@@ -23,11 +23,26 @@ oboe-main.jl
 
 module OboeMain
 
-#The FIPS codes for each of the contiguous US states (and DC)
+"The FIPS codes for each of the contiguous US states (and DC)"
 fipsAll =  ["01", "04", "05", "06", "08", "09", "10", "11", "12", "13", "16", "17", "18",
             "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
             "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "44", "45",
             "46", "47", "48", "49", "50", "51", "53", "54", "55", "56"]
+
+"Wash. + Ore, 2072 tracts"
+fipsNW = ["41","53"]
+
+"NW's first neighbors except Cal., 2834 tracts"
+fipsNW1 = ["16","32","41","53"]
+
+"NW's 1st and 2nd neighbors except Cal., 4830 tracts, 259 ctys"
+fipsNW2 = ["04","16","30","32","41","49","53","56"]
+
+"Cal., 7038 tracts, 58 ctys"
+fipsCA = ["06"]
+
+"West Coast, Cal. + Ore. + Wash., 9910 tracts, 133 ctys"
+fipsWCT= ["06","41","53"]
 
 
 using FromFile
@@ -40,6 +55,9 @@ println(Oboe.callsign)
 
 #lame logging thing
 myshow = obj -> println(first(obj,5))
+
+"blueprint for getProcessedAPs() method "
+#Oboe.getProcessedAPs(Oboe.rdBTS() |> Oboe.grpBTS,Oboe.rdAPs())
 
 function processOboe(name, agg; fips=fipsAll, useNW=false, force=false)
     #construct the output file name and make sure the files don't already exist

--- a/tools/scratch-nb/test-infect2.ipynb
+++ b/tools/scratch-nb/test-infect2.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89b5b5c940aab2d26862534fcf5e94da3d6de886411b0e5429eabc4a3377e50f
-size 30664
+oid sha256:946a0c7c4db71d9e2486219759678cbd84858f4cc602ceebe0a0872fbe2201ca
+size 53215

--- a/tools/scratch-nb/test-infect2.ipynb
+++ b/tools/scratch-nb/test-infect2.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89b5b5c940aab2d26862534fcf5e94da3d6de886411b0e5429eabc4a3377e50f
+size 30664


### PR DESCRIPTION
Couple of tweaks made for another conference submission:
* Isolated the dispatching of aggregation and partition functions by the `agg` string and stuck that straight into oboe-main.jl
* Added `infect2!` which attempts to start the infection in census tract 950100, Baker Cty., Ore., or its designated airport ALW if these are found in the initial values table, or else, the first node
* Set the main processing `processOboe` to default to `infect2!`
* Re-generated instances I needed for a Sep 12th conference submission; also removed the unused ones.
* Restored `talkDnsy`, which must've been omitted during a rewrite. This is a useful auxiliary to appraise how sparse and how “fast” the transportation networks are. Stuck this one into travel.jl together with `mk[Psg|Cmt]Mx`, which is what `talkDnsy` is usually called on. 

This PR is just to raise attention, but meaningful comments are appreciated.