### PR TITLE
rewrite node-average infected fraction and control effort plot 

### DIFF
--- a/m-core/figSimplex.m
+++ b/m-core/figSimplex.m
@@ -6,7 +6,7 @@ function [outFig] = figSimplex(s_in, z_in, nodeTag)
 outFig = newplot;
 fplot(@(x) 1-x, [0,max(z_in,[],'all')]);
 hold on;
-plot(z_in',s_in',':+');
+plot(z_in',s_in','-');
 hold off;
     
 %title and axis labels

--- a/m-core/sweep.m
+++ b/m-core/sweep.m
@@ -25,7 +25,7 @@
 % 2021-03-18 v.1.1.1 add the transpose, made control 10 times cheaper
 % 2021-03-25 v.1.2 add ZZ: abs. infected at T and cZR: abs. Z + R (T)
 %            v.1.2.1 add norm-to-1-node output avgOut [z01; z11; avg_u]
-% 2021-10-04 v.1.2.2 add header to norm-to-1-node CSV output
+% 2021-10-04 v.1.2.2 rehaul avgOut to output as a CSV with header
 
 %% TODO
 % 1 debug output (time, errors, J, &c) to a log file
@@ -118,6 +118,9 @@ inst="NWcty_75"; %by-county OR + WS, with flights & commute
 %inst="ALLste_49";
 
 %inst = "NW1tra_2834";
+%inst = "NW1cty_136";
+%inst = "NW1ap_37";
+%inst = "NW1ste_4";
 
 %inst = "NW2ste_8";
 %inst = "NW2ap_74";
@@ -297,7 +300,7 @@ cns = [arrayfun( @(n) 's'+string(n),0:T) ...
      arrayfun( @(n) 'r'+string(n),0:T)];
 
 %col. names for per-node average infected-null, infected-opt, control effort
-cns_avgc = ["z_avg","zNull_avg","u_avg"];
+cns_avgc = ["zNull_avg","z_avg","u_avg"];
  
 %construct the solution output tables
 otfrac = horzcat(tIVs,array2table([s z r],'VariableNames',cns));

--- a/tools/vl-post-viz.jl
+++ b/tools/vl-post-viz.jl
@@ -9,7 +9,7 @@ This one is mostly for _a posteriori_ figures:
 
 Yaroslav Salii, 2021
 2021-08-25 v.0.0 all plots automated
-2021-10-04 v.0.1 adding avg infected rate and control line plot
+2021-10-04 v.0.1 add avg infected vs avg control line plot
 """
 
 using VegaLite,VegaDatasets
@@ -33,7 +33,11 @@ pwd()
 #@from "./Oboe/Oboe.jl" import Oboe
 
 #====PREP==THE==DATA=================#
-slnName="NWcty_75"
+#slnName="NWcty_75"
+#slnName="NWste_2"
+#slnName="NWap_23"
+slnName="NWtra_2072"
+fips=["41","53"]
 #paths to solutions in fractions, optimal control and null-control
 #slnOptPath=joinpath(iDir,slnName*"-frac.csv")
 #slnNullPath=joinpath(iDir,slnName*"-frac0.csv")
@@ -57,9 +61,44 @@ ss = rdSolutions()
 "-avg.csv" has 3 columns: z_avg; zNull_avg; u_avg, and per-day rows. Gotta fix that in MATLAB. 
 also, I should isolate the fundamental plot specs as functions that take the data ("INSERT DF HERE")
 =#
+#insert day numbers
+insertcols!(ss.avgc,1,:day => 0:(nrow(ss.avgc)-1))
+long_avgc = stack(ss.avgc,[:z_avg,:zNull_avg,:u_avg],variable_name=:symbol)
+
 
 a0Median = ss.a0.Z180 |> median
 a0Max = ss.a0.Z180 |> maximum
+
+
+#====PLOT==AVG==INFECTED==AND==CONTROL===#
+pltAvgInfdCtrl = @vlplot(
+    data = long_avgc,
+    :line,
+    x=:day,
+    y=:value,
+    color={
+        :symbol, 
+        scale={
+            domain=["zNull_avg","z_avg","u_avg"],
+            range = ["#E31A1C","#FB9A99","#33A02C"] #red, pink, green
+            #scheme=:paired
+        },
+        #legend = nothing
+        legend = {
+            orient = "top-right",
+            #values=["lorem","ipsum","sit"]
+            title = "variable",
+        }
+        },
+)
+
+
+pathPlotAvgZC=joinpath(figDir,slnName * "-avgzc" *".pdf") 
+
+
+save(pathPlotAvgZC,pltAvgInfdCtrl)
+
+
 
 #====PLOT==ABS==INFECTED=======#
 
@@ -205,6 +244,29 @@ save(plotPaths[3],pltIVs)
 #map(p -> save(p[1],p[2]),(plotPaths .=> [pltOpt,pltNull,pltIVs]))
 
 #=========BIT====BUCKET===============#
+# these plot each line separately
+# pltAvg_zNull= @vlplot(
+#     data = ss.avgc,    
+#     :line,
+#     x=:day,
+#     y=:zNull_avg
+# )
+
+# pltAvg_zOpt= @vlplot(
+#     data = ss.avgc,    
+#     :line,
+#     x=:day,
+#     y=:z_avg
+# )
+
+# pltAvg_ctrl= @vlplot(
+#     data = ss.avgc,    
+#     :line,
+#     x=:day,
+#     y=:u_avg
+# )
+
+
 #note: reused from vl-pre-viz.jl, candidate for isolation
 # pltCanvasSte = @vlplot(
 #     mark={

--- a/tools/vl-post-viz.jl
+++ b/tools/vl-post-viz.jl
@@ -9,6 +9,7 @@ This one is mostly for _a posteriori_ figures:
 
 Yaroslav Salii, 2021
 2021-08-25 v.0.0 all plots automated
+2021-10-04 v.0.1 adding avg infected rate and control line plot
 """
 
 using VegaLite,VegaDatasets
@@ -33,22 +34,29 @@ pwd()
 
 #====PREP==THE==DATA=================#
 slnName="NWcty_75"
-#paths to solutions in fracitons, optimal control and null-control
-slnOptPath=joinpath(iDir,slnName*"-frac.csv")
-slnNullPath=joinpath(iDir,slnName*"-frac0.csv")
+#paths to solutions in fractions, optimal control and null-control
+#slnOptPath=joinpath(iDir,slnName*"-frac.csv")
+#slnNullPath=joinpath(iDir,slnName*"-frac0.csv")
 
-#read them
-slnOpt=CSV.read(slnOptPath,DataFrame)
-slnNull=CSV.read(slnNullPath,DataFrame)
-
-"""read the solutions into dataframes and stuff them into a named tuple """
+"""
+Read the solutions into dataframes and stuff them into a named tuple 
+:f,:f0 are *fractional* per-node per-day s/z/r
+:a,:a0 are *absolute* per-node per-day S/Z/R 
+:avgc are per-day average infected fraction z, zNull, and average optimal control effort u
+"""
 function rdSolutions(;iName = slnName, slnDir = iDir )
-    slnSuffs = ["-frac.csv","-frac0.csv","-abs.csv","-abs0.csv"]
+    slnSuffs = ["-frac.csv","-frac0.csv","-abs.csv","-abs0.csv","-avg.csv"]
     slns= map( p -> CSV.read(p,DataFrame), (joinpath(iDir,slnName * suff) for suff in slnSuffs))
-    return NamedTuple([:f,:f0,:a,:a0] .=> slns) 
+    return NamedTuple([:f,:f0,:a,:a0,:avgc] .=> slns) 
 end
 
+#do read all the solutions
 ss = rdSolutions()
+
+#=
+"-avg.csv" has 3 columns: z_avg; zNull_avg; u_avg, and per-day rows. Gotta fix that in MATLAB. 
+also, I should isolate the fundamental plot specs as functions that take the data ("INSERT DF HERE")
+=#
 
 a0Median = ss.a0.Z180 |> median
 a0Max = ss.a0.Z180 |> maximum
@@ -176,7 +184,7 @@ pltBoundarySte = @vlplot(
         }
     },
     transform=[{
-            filter={field =:id,oneOf = fips}
+            filter={field =:id,oneOf = fips} #insert state(?) FIPS
             }],
     projection={type=:albersUsa},
 )


### PR DESCRIPTION
The subj was done internally in the MATLAB core, with not quite complete `-avg.csv` autput.

I rewrote the plot to use VegaLite.jl, mostly for consistency, to do which I also had to fix the output. 

Though I like the resulting _new style_ pictures (see below), I did not like the following:
* no LaTeX support in the legend
* the input had to be made into *long* format (praise `stack`/`unstack`): I haven't figured out how to use the column pairs (day, value) as lines, which I expected I could do
* it was _not_ convenient to edit single line properties, so instead of using *red dash* I had to resort to paired *salmon pink* color

Seriously consider engaging Plots.jl, Gadfly, or whichever proves more convenient for line (function graph!) plots.

New style (VegaLite.jl, “paired” color set scheme):
<img width="289" alt="Screen Shot 2021-10-06 at 3 41 35 PM" src="https://user-images.githubusercontent.com/49194796/136272045-ad76aa43-eea2-4281-8b27-5aaf321fa64e.png">
Old style (Matlab, `plot`, colors are from the default set, lines are thicker than default)
![NWcty75-AVG](https://user-images.githubusercontent.com/49194796/136273040-78b32b4f-50ba-4460-a848-3fb9c75e8cf7.png)


 